### PR TITLE
use `arc info` instead of `.arc/HEAD` parsing

### DIFF
--- a/zsh-arc.plugin.zsh
+++ b/zsh-arc.plugin.zsh
@@ -2,8 +2,9 @@
 # Based on https://github.com/ohmyzsh/ohmyzsh/blob/2eb3e9d57cf69f3c2fa557f9047e0a648d80b235/plugins/git/git.plugin.zsh
 
 function arc_current_branch() {
-  if arc root &> /dev/null; then
-    cat $(arc root)/.arc/HEAD | sed 's/Symbolic: "\(.*\)"/\1/'
+  local branch_info=$(arc info 2> /dev/null | grep '^branch:')
+  if [ -n "$branch_info" ]; then
+    echo ${branch_info#branch: }
   fi
 }
 


### PR DESCRIPTION
Format of `.arc` directory is not a part of public contract and can be changed in the future.
It's better to use `arc info` to fetch information about the working copy.